### PR TITLE
Move to newer release of capp

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -70,7 +70,7 @@ func (in *PlunderCluster) DeepCopyObject() runtime.Object {
 func (in *PlunderClusterList) DeepCopyInto(out *PlunderClusterList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]PlunderCluster, len(*in))
@@ -164,7 +164,7 @@ func (in *PlunderMachine) DeepCopyObject() runtime.Object {
 func (in *PlunderMachineList) DeepCopyInto(out *PlunderMachineList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]PlunderMachine, len(*in))

--- a/cluster-api-plunder-components.yaml
+++ b/cluster-api-plunder-components.yaml
@@ -125,8 +125,6 @@ spec:
                 (SPOILER IT ISN'T as i've not written it yet)
               type: string
             macaddress:
-              description: MACAddress is the physical network address of the if we
-                don't auto detect
               type: string
             providerID:
               description: 'ProviderID will be the only detail (todo: something else)'
@@ -141,10 +139,14 @@ spec:
             macaddress:
               description: MACAddress is the physical network address of the machine
               type: string
+            machineName:
+              description: MachineName is the generated name for the provisioned name
+              type: string
             ready:
               description: Ready denotes that the machine is ready
               type: boolean
           required:
+          - machineName
           - ready
           type: object
       type: object
@@ -180,14 +182,12 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        image: thebsdbox/capp:v0.1
+        image: thebsdbox/capp:v0.1.1
         name: manager
         volumeMounts:
         - name: plunderyaml
           mountPath: "/plunderclient.yaml"
           subPath: "plunderclient.yaml"
-        securityContext:
-          privileged: true
       terminationGracePeriodSeconds: 10
       volumes:
       - name: plunderyaml

--- a/hack/dockerBuild/build.sh
+++ b/hack/dockerBuild/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+VERSION=v0.1.1
+
 echo "This is a terrible way for building the controller, but feel free to come up with something nicer"
 
 cd ../..
@@ -33,7 +35,7 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        image: thebsdbox/capp:v0.1
+        image: thebsdbox/capp:$VERSION
         name: manager
         volumeMounts:
         - name: plunderyaml
@@ -50,8 +52,8 @@ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o hack/dockerB
 
 cd -
 
-docker build -t thebsdbox/capp:v0.1 .
-docker push thebsdbox/capp:v0.1
+docker build -t thebsdbox/capp:$VERSION .
+docker push thebsdbox/capp:$VERSION
 
 echo "Tidying up working directory, then inspect the docker images"
 rm manager


### PR DESCRIPTION
Moves from v0.1 to v0.1.1 (captures the code cleanup changes), also removes an oddity around privileges in the controller.